### PR TITLE
MALClient.sln: fix project name case

### DIFF
--- a/MALClient.sln
+++ b/MALClient.sln
@@ -66,7 +66,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Binding_Droppy", "MALClient
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MALClient.UWP.BGTaskLiveTilesNotifications", "MALClient.UWP.BGTaskLiveTilesNotifications\MALClient.UWP.BGTaskLiveTilesNotifications.csproj", "{22C7343B-FEF3-45B2-91C3-79EF25C0CAC5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MALClient.UrlInterceptor", "MALClient.UrlInterceptor\MALClient.UrlInterceptor.csproj", "{33777EF3-06CB-4289-B479-7B301645F82B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MALClient.UrlInterceptor", "MALCLient.UrlInterceptor\MALCLient.UrlInterceptor.csproj", "{33777EF3-06CB-4289-B479-7B301645F82B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UrlInterceptor", "UrlInterceptor", "{B72B7F82-B518-4496-AC4B-AF249A121CEE}"
 EndProject


### PR DESCRIPTION
Otherwise, it fails to load on Linux which is case-sensitive.

An other solution (to have consistency with the other names) could be to rename the folder and the project file but I think it is not ideal for the git history. I leave the decision up to you.