### PR TITLE
Black navigation bar for AMOLED theme

### DIFF
--- a/MALClient.Android/Resources/values/styles.xml
+++ b/MALClient.Android/Resources/values/styles.xml
@@ -423,6 +423,7 @@
     <item name="BrushDetailsBackground">@android:color/black</item>
     <item name="BrushDetailsUpperBackground">@android:color/black</item>
     <item name="android:colorPrimaryDark">@android:color/black</item>
+    <item name="android:navigationBarColor">@android:color/black</item>
   </style>
 
   <style name="Theme.MALClient.Light" parent="Theme.AppCompat.Light.NoActionBar">


### PR DESCRIPTION
I like the AMOLED theme but the white navigation bar has been bothering me. Wouldn't it make more sense to have it in black?