### PR TITLE
Fix episode format suffix for numbers ending in 1-3

### DIFF
--- a/MALClient.XShared/BL/ShareManager.cs
+++ b/MALClient.XShared/BL/ShareManager.cs
@@ -159,14 +159,17 @@ namespace MALClient.XShared.BL
 
         private string FormatEpisode(int ep)
         {
-            switch (ep)
+            if (ep % 100 > 3 && ep % 100 < 21)
+                return $"{ep}th";
+
+            switch (ep % 10)
             {
                 case 1:
-                    return "1st";
+                    return $"{ep}st";
                 case 2:
-                    return "2nd";
+                    return $"{ep}nd";
                 case 3:
-                    return "3rd";
+                    return $"{ep}rd";
                 default:
                     return $"{ep}th";
             }


### PR DESCRIPTION
Makes the function FormatEpisode in ShareManager return with the proper suffix for numbers ending with 1-3, so no more "I've just watched the 21th episode of X".

Includes a check for 11-13 to avoid "11st", "112nd", and so on.