### PR TITLE
Fix "statistics" typo

### DIFF
--- a/MALClient.Desktop/Pages/Off/AnimeDetailsPage.xaml
+++ b/MALClient.Desktop/Pages/Off/AnimeDetailsPage.xaml
@@ -1135,7 +1135,7 @@
                                         </StackPanel>
                                         <MenuFlyoutSeparator Margin="0,5" />
                                         <StackPanel>
-                                            <TextBlock Text="Statisctics" FontWeight="Bold" VerticalAlignment="Top"
+                                            <TextBlock Text="Statistics" FontWeight="Bold" VerticalAlignment="Top"
                                                        HorizontalAlignment="Center" FontSize="17" Margin="0,5,0,5" />
                                             <userControls:AlternatingListView ItemsSource="{Binding Stats}"
                                                                               ItemContainerStyle="{StaticResource DetailsItemStyle}">

--- a/MALClient.Mobile/Pages/Off/AnimeDetailsPage.xaml
+++ b/MALClient.Mobile/Pages/Off/AnimeDetailsPage.xaml
@@ -1152,7 +1152,7 @@
                                                     </StackPanel>
                                                     <MenuFlyoutSeparator Margin="0,5"/>
                                                     <StackPanel>
-                                                        <TextBlock Text="Statisctics" FontWeight="Bold" VerticalAlignment="Top"
+                                                        <TextBlock Text="Statistics" FontWeight="Bold" VerticalAlignment="Top"
                                                    HorizontalAlignment="Center" FontSize="17" Margin="0,5,0,5" />
                                                         <userControls:AlternatingListView ScrollViewer.VerticalScrollMode="Disabled" ItemsSource="{Binding Stats}" ItemContainerStyle="{StaticResource DetailsItemStyle}">
                                                             <ListView.ItemTemplate>


### PR DESCRIPTION
On anime Details page, "statistics" is spelled as "statisctics". This PR fixes that misspelling. 